### PR TITLE
ignore some generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
+BoostTestTargetConfig.h
+CTestTestfile.cmake
+DartConfiguration.tcl
+Testing


### PR DESCRIPTION
The build process produces 3 files and a "Testing" directory which should be ignored by Git.
