### PR TITLE
removed the additional memory buffer for assembly files

### DIFF
--- a/include/AssemblyFileWriter.hpp
+++ b/include/AssemblyFileWriter.hpp
@@ -8,7 +8,6 @@
 #ifndef ASSEMBLY_FILE_WRITER_H
 #define ASSEMBLY_FILE_WRITER_H
 
-#include <sstream>
 #include <fstream>
 
 namespace eddic {
@@ -22,7 +21,6 @@ namespace eddic {
 class AssemblyFileWriter {
     private:
         std::ofstream m_stream;
-        std::stringstream buffer;
 	
     public:
     	/*!
@@ -41,14 +39,7 @@ class AssemblyFileWriter {
          * This method should be used to output assembly instruction to the file. 
          * \return A reference to the enclosing stream. 
          */
-        std::stringstream& stream();
-        
-        /*!
-         * Output the buffer to the file. 
-         */
-        void write();
-
-        unsigned int size();
+        std::ostream& stream();
 };
 
 } //end of eddic

--- a/src/AssemblyFileWriter.cpp
+++ b/src/AssemblyFileWriter.cpp
@@ -20,17 +20,9 @@ AssemblyFileWriter::AssemblyFileWriter(const std::string& path) {
 }
 
 AssemblyFileWriter::~AssemblyFileWriter() {
-    m_stream.close();
 }
 
-std::stringstream& AssemblyFileWriter::stream() {
-    return buffer;
+std::ostream& AssemblyFileWriter::stream() {
+    return m_stream;
 }
 
-unsigned int AssemblyFileWriter::size() {
-    return buffer.str().size();
-}
-
-void AssemblyFileWriter::write(){
-    m_stream.write(buffer.str().c_str(), buffer.str().length());
-}

--- a/src/NativeBackEnd.cpp
+++ b/src/NativeBackEnd.cpp
@@ -81,17 +81,18 @@ void NativeBackEnd::generate(mtac::program_p mtac_program, Platform platform){
         auto asm_file_name = input_file_name + ".s";
         auto object_file_name = input_file_name + ".o";
 
-        //Generate assembly from TAC
-        AssemblyFileWriter writer(asm_file_name);
+        {
+            //Generate assembly from TAC
+            AssemblyFileWriter writer(asm_file_name);
 
-        as::CodeGeneratorFactory factory;
-        auto generator = factory.get(platform, writer, mtac_program->context);
+            as::CodeGeneratorFactory factory;
+            auto generator = factory.get(platform, writer, mtac_program->context);
 
-        //Generate the code from the LTAC Program
-        generator->generate(mtac_program, get_string_pool(), float_pool); 
+            //Generate the code from the LTAC Program
+            generator->generate(mtac_program, get_string_pool(), float_pool);
 
-        //Write the output
-        writer.write(); 
+            //writer's destructor flushes the file
+        }
 
         //If it's necessary, assemble and link the assembly
         if(!configuration->option_defined("assembly")){

--- a/src/asm/IntelAssemblyUtils.cpp
+++ b/src/asm/IntelAssemblyUtils.cpp
@@ -13,7 +13,7 @@ using namespace eddic;
 
 void eddic::as::save(AssemblyFileWriter& writer, const std::vector<std::string>& registers){
     for(auto& reg : registers){
-        writer.stream() << "push " << reg << std::endl;
+        writer.stream() << "push " << reg << '\n';
     }
 }
 
@@ -22,7 +22,7 @@ void eddic::as::restore(AssemblyFileWriter& writer, const std::vector<std::strin
     auto end = registers.rend();
 
     while(it != end){
-        writer.stream() << "pop " << *it << std::endl;
+        writer.stream() << "pop " << *it << '\n';
         ++it;
     }
 }

--- a/src/asm/IntelCodeGenerator.cpp
+++ b/src/asm/IntelCodeGenerator.cpp
@@ -34,13 +34,6 @@ void as::IntelCodeGenerator::generate(mtac::program_p program, std::shared_ptr<S
     addStandardFunctions();
 
     addGlobalVariables(pool, float_pool);
-
-    auto size = writer.size();
-
-    //Little hack in order for nasm to work with little files
-    for(int i = size; i < 1050; ++i){
-        writer.stream() << " " << std::endl;
-    }
 }
 
 void as::IntelCodeGenerator::addGlobalVariables(std::shared_ptr<StringPool> pool, std::shared_ptr<FloatPool> float_pool){
@@ -91,19 +84,17 @@ void as::IntelCodeGenerator::output_function(const std::string& function){
 
     eddic_assert(stream, "One file in the functions folder does not exist");
 
-    std::string str;
-
-    while(!stream.eof()){
-        std::getline(stream, str);
-
-        if(!str.empty()){
-            if(str[0] != ';'){
-                writer.stream() << str << std::endl;
-            }
+    std::string line;
+    while (getline(stream, line))
+    {
+        if (!line.empty() &&
+            (line[0] != ';'))
+        {
+            writer.stream() << line << '\n';
         }
     }
-
-    writer.stream() << std::endl;
+    
+    writer.stream() << '\n';
 }
 
 

--- a/src/asm/IntelX86CodeGenerator.cpp
+++ b/src/asm/IntelX86CodeGenerator.cpp
@@ -101,13 +101,13 @@ struct X86StatementCompiler : public boost::static_visitor<> {
                 if(instruction->size != ltac::Size::DEFAULT){
                     switch(instruction->size){
                         case ltac::Size::BYTE:
-                            writer.stream() << "movzx " << *instruction->arg1 << ", byte " << *instruction->arg2 << std::endl;
+                            writer.stream() << "movzx " << *instruction->arg1 << ", byte " << *instruction->arg2 << '\n';
                             break;
                         case ltac::Size::WORD:
-                            writer.stream() << "movzx " << *instruction->arg1 << ", word " << *instruction->arg2 << std::endl;
+                            writer.stream() << "movzx " << *instruction->arg1 << ", word " << *instruction->arg2 << '\n';
                             break;
                         default:
-                            writer.stream() << "mov " << *instruction->arg1 << ", dword " << *instruction->arg2 << std::endl;
+                            writer.stream() << "mov " << *instruction->arg1 << ", dword " << *instruction->arg2 << '\n';
                             break;
                     }
 
@@ -115,154 +115,154 @@ struct X86StatementCompiler : public boost::static_visitor<> {
                 }
 
                 if(boost::get<ltac::FloatRegister>(&*instruction->arg1) && boost::get<ltac::Register>(&*instruction->arg2)){
-                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else if(boost::get<ltac::Register>(&*instruction->arg1) && boost::get<ltac::FloatRegister>(&*instruction->arg2)){
-                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else if(boost::get<ltac::Address>(&*instruction->arg1)){
-                    writer.stream() << "mov dword " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "mov dword " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else {
-                    writer.stream() << "mov " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "mov " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::FMOV:
                 if(boost::get<ltac::FloatRegister>(&*instruction->arg1) && boost::get<ltac::Register>(&*instruction->arg2)){
-                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else {
-                    writer.stream() << "movss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::MEMSET:
-                writer.stream() << "mov ecx, " << *instruction->arg2 << std::endl;
-                writer.stream() << "xor eax, eax" << std::endl;
-                writer.stream() << "lea edi, " << *instruction->arg1 << std::endl;
-                writer.stream() << "rep stosw" << std::endl;
+                writer.stream() << "mov ecx, " << *instruction->arg2 << '\n';
+                writer.stream() << "xor eax, eax" << '\n';
+                writer.stream() << "lea edi, " << *instruction->arg1 << '\n';
+                writer.stream() << "rep stosw" << '\n';
 
                 break;
             case ltac::Operator::ENTER:
-                writer.stream() << "push ebp" << std::endl;
-                writer.stream() << "mov ebp, esp" << std::endl;
+                writer.stream() << "push ebp" << '\n';
+                writer.stream() << "mov ebp, esp" << '\n';
                 break;
             case ltac::Operator::LEAVE:
-                writer.stream() << "mov esp, ebp" << std::endl;
-                writer.stream() << "pop ebp" << std::endl;
+                writer.stream() << "mov esp, ebp" << '\n';
+                writer.stream() << "pop ebp" << '\n';
                 break;
             case ltac::Operator::RET:
-                writer.stream() << "ret" << std::endl;
+                writer.stream() << "ret" << '\n';
                 break;
             case ltac::Operator::CMP_INT:
-                writer.stream() << "cmp " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmp " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMP_FLOAT:
-                writer.stream() << "ucomiss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "ucomiss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::OR:
-                writer.stream() << "or " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "or " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::XOR:
-                writer.stream() << "xor " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "xor " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::PUSH:
                 if(boost::get<ltac::Address>(&*instruction->arg1)){
-                    writer.stream() << "push dword " << *instruction->arg1 << std::endl;
+                    writer.stream() << "push dword " << *instruction->arg1 << '\n';
                 } else {
-                    writer.stream() << "push " << *instruction->arg1 << std::endl;
+                    writer.stream() << "push " << *instruction->arg1 << '\n';
                 }
 
                 break;
             case ltac::Operator::POP:
-                writer.stream() << "pop " << *instruction->arg1 << std::endl;
+                writer.stream() << "pop " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::LEA:
-                writer.stream() << "lea " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "lea " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SHIFT_LEFT:
-                writer.stream() << "sal " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sal " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SHIFT_RIGHT:
-                writer.stream() << "sar " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sar " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::ADD:
-                writer.stream() << "add " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "add " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SUB:
-                writer.stream() << "sub " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sub " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::MUL2:
             case ltac::Operator::MUL3:
                 if(instruction->arg3){
-                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << ", " << *instruction->arg3 << std::endl;
+                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << ", " << *instruction->arg3 << '\n';
                 } else {
-                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::DIV:
-                writer.stream() << "idiv " << *instruction->arg1 << std::endl;
+                writer.stream() << "idiv " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::FADD:
-                writer.stream() << "addss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "addss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FSUB:
-                writer.stream() << "subss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "subss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FMUL:
-                writer.stream() << "mulss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "mulss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FDIV:
-                writer.stream() << "divss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "divss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::INC:
-                writer.stream() << "inc " << *instruction->arg1 << std::endl;
+                writer.stream() << "inc " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::DEC:
-                writer.stream() << "dec " << *instruction->arg1 << std::endl;
+                writer.stream() << "dec " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::NEG:
-                writer.stream() << "neg " << *instruction->arg1 << std::endl;
+                writer.stream() << "neg " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::NOT:
-                writer.stream() << "not " << *instruction->arg1 << std::endl;
+                writer.stream() << "not " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::AND:
-                writer.stream() << "and " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "and " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::I2F:
-                writer.stream() << "cvtsi2ss " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cvtsi2ss " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::F2I:
-                writer.stream() << "cvttss2si " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cvttss2si " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVE:
-                writer.stream() << "cmove " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmove " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVNE:
-                writer.stream() << "cmovne " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovne " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVA:
-                writer.stream() << "cmova " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmova " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVAE:
-                writer.stream() << "cmovae " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovae " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVB:
-                writer.stream() << "cmovb " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovb " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVBE:
-                writer.stream() << "cmovbe " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovbe " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVG:
-                writer.stream() << "cmovg " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovg " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVGE:
-                writer.stream() << "cmovge " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovge " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVL:
-                writer.stream() << "cmovl " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovl " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVLE:
-                writer.stream() << "cmovle " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovle " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::NOP:
                 //Nothing to output for a nop
@@ -275,49 +275,49 @@ struct X86StatementCompiler : public boost::static_visitor<> {
     void operator()(std::shared_ptr<ltac::Jump> jump){
         switch(jump->type){
             case ltac::JumpType::CALL:
-                writer.stream() << "call " << jump->label << std::endl;
+                writer.stream() << "call " << jump->label << '\n';
                 break;
             case ltac::JumpType::ALWAYS:
-                writer.stream() << "jmp " << "." << jump->label << std::endl;
+                writer.stream() << "jmp " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::NE:
-                writer.stream() << "jne " << "." << jump->label << std::endl;
+                writer.stream() << "jne " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::E:
-                writer.stream() << "je " << "." << jump->label << std::endl;
+                writer.stream() << "je " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::GE:
-                writer.stream() << "jge " << "." << jump->label << std::endl;
+                writer.stream() << "jge " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::G:
-                writer.stream() << "jg " << "." << jump->label << std::endl;
+                writer.stream() << "jg " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::LE:
-                writer.stream() << "jle " << "." << jump->label << std::endl;
+                writer.stream() << "jle " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::L:
-                writer.stream() << "jl " << "." << jump->label << std::endl;
+                writer.stream() << "jl " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::AE:
-                writer.stream() << "jae " << "." << jump->label << std::endl;
+                writer.stream() << "jae " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::A:
-                writer.stream() << "ja" << "." << jump->label << std::endl;
+                writer.stream() << "ja" << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::BE:
-                writer.stream() << "jbe " << "." << jump->label << std::endl;
+                writer.stream() << "jbe " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::B:
-                writer.stream() << "jb " << "." << jump->label << std::endl;
+                writer.stream() << "jb " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::P:
-                writer.stream() << "jp " << "." << jump->label << std::endl;
+                writer.stream() << "jp " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::Z:
-                writer.stream() << "jz " << "." << jump->label << std::endl;
+                writer.stream() << "jz " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::NZ:
-                writer.stream() << "jnz " << "." << jump->label << std::endl;
+                writer.stream() << "jnz " << "." << jump->label << '\n';
                 break;
             default:
                 eddic_unreachable("The jump type is not supported");
@@ -325,14 +325,14 @@ struct X86StatementCompiler : public boost::static_visitor<> {
     }
 
     void operator()(std::string& label){
-        writer.stream() << "." << label << ":" << std::endl;
+        writer.stream() << "." << label << ":" << '\n';
     }
 };
 
 } //end of anonymous namespace
 
 void as::IntelX86CodeGenerator::compile(mtac::function_p function){
-    writer.stream() << std::endl << function->getName() << ":" << std::endl;
+    writer.stream() << '\n' << function->getName() << ":" << '\n';
 
     X86StatementCompiler compiler(writer);
 
@@ -342,103 +342,103 @@ void as::IntelX86CodeGenerator::compile(mtac::function_p function){
 }
 
 void as::IntelX86CodeGenerator::writeRuntimeSupport(){
-    writer.stream() << "section .text" << std::endl << std::endl;
+    writer.stream() << "section .text" << '\n' << '\n';
 
-    writer.stream() << "global _start" << std::endl << std::endl;
+    writer.stream() << "global _start" << '\n' << '\n';
 
-    writer.stream() << "_start:" << std::endl;
+    writer.stream() << "_start:" << '\n';
     
     //If necessary init memory manager 
     if(context->exists("_F4mainAS") || context->referenceCount("_F4freePI") || context->referenceCount("_F5allocI") || context->referenceCount("_F6concatSS")){
-        writer.stream() << "call _F4init" << std::endl; 
+        writer.stream() << "call _F4init" << '\n'; 
     }
 
     //If the user wants the args, we add support for them
     if(context->exists("_F4mainAS")){
-        writer.stream() << "pop ebx" << std::endl;                          //ebx = number of args
+        writer.stream() << "pop ebx" << '\n';                          //ebx = number of args
         
-        writer.stream() << "lea ecx, [4 + ebx * 8]" << std::endl;           //ecx = size of the array
-        writer.stream() << "call _F5allocI" << std::endl;                  //eax = start address of the array
+        writer.stream() << "lea ecx, [4 + ebx * 8]" << '\n';           //ecx = size of the array
+        writer.stream() << "call _F5allocI" << '\n';                  //eax = start address of the array
 
-        writer.stream() << "mov esi, eax" << std::endl;         //esi = last address of the array
-        writer.stream() << "mov edx, esi" << std::endl;                     //edx = last address of the array
+        writer.stream() << "mov esi, eax" << '\n';         //esi = last address of the array
+        writer.stream() << "mov edx, esi" << '\n';                     //edx = last address of the array
         
-        writer.stream() << "mov [esi], ebx" << std::endl;                   //Set the length of the array
-        writer.stream() << "add esi, 4" << std::endl;                       //Move to the destination address of the first arg
+        writer.stream() << "mov [esi], ebx" << '\n';                   //Set the length of the array
+        writer.stream() << "add esi, 4" << '\n';                       //Move to the destination address of the first arg
 
-        writer.stream() << ".copy_args:" << std::endl;
-        writer.stream() << "pop edi" << std::endl;                          //edi = address of current args
-        writer.stream() << "mov [esi], edi" << std::endl;                 //set the address of the string
+        writer.stream() << ".copy_args:" << '\n';
+        writer.stream() << "pop edi" << '\n';                          //edi = address of current args
+        writer.stream() << "mov [esi], edi" << '\n';                 //set the address of the string
 
         /* Calculate the length of the string  */
-        writer.stream() << "xor eax, eax" << std::endl;
-        writer.stream() << "xor ecx, ecx" << std::endl;
-        writer.stream() << "not ecx" << std::endl;
-        writer.stream() << "repne scasb" << std::endl;
-        writer.stream() << "not ecx" << std::endl;
-        writer.stream() << "dec ecx" << std::endl;
+        writer.stream() << "xor eax, eax" << '\n';
+        writer.stream() << "xor ecx, ecx" << '\n';
+        writer.stream() << "not ecx" << '\n';
+        writer.stream() << "repne scasb" << '\n';
+        writer.stream() << "not ecx" << '\n';
+        writer.stream() << "dec ecx" << '\n';
         /* End of the calculation */
 
-        writer.stream() << "mov [esi+4], ecx" << std::endl;               //set the length of the string
-        writer.stream() << "add esi, 8" << std::endl;
-        writer.stream() << "dec ebx" << std::endl;
-        writer.stream() << "jnz .copy_args" << std::endl;
+        writer.stream() << "mov [esi+4], ecx" << '\n';               //set the length of the string
+        writer.stream() << "add esi, 8" << '\n';
+        writer.stream() << "dec ebx" << '\n';
+        writer.stream() << "jnz .copy_args" << '\n';
 
-        writer.stream() << "push edx" << std::endl;
+        writer.stream() << "push edx" << '\n';
     }
 
     /* Give control to the user main function */
     if(context->exists("_F4mainAS")){
-        writer.stream() << "call _F4mainAS" << std::endl;
+        writer.stream() << "call _F4mainAS" << '\n';
     } else {
-        writer.stream() << "call _F4main" << std::endl;
+        writer.stream() << "call _F4main" << '\n';
     }
     
     /* Exit the program */
-    writer.stream() << "mov eax, 1" << std::endl;
-    writer.stream() << "xor ebx, ebx" << std::endl;
-    writer.stream() << "int 80h" << std::endl;
+    writer.stream() << "mov eax, 1" << '\n';
+    writer.stream() << "xor ebx, ebx" << '\n';
+    writer.stream() << "int 80h" << '\n';
 }
 
 void as::IntelX86CodeGenerator::defineDataSection(){
-    writer.stream() << std::endl << "section .data" << std::endl;
+    writer.stream() << '\n' << "section .data" << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareIntArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dd " << size << std::endl;
-    writer.stream() << "times " << size << " dd 0" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dd " << size << '\n';
+    writer.stream() << "times " << size << " dd 0" << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareFloatArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dd " << size << std::endl;
-    writer.stream() << "times " << size << " dd __float32__(0.0)" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dd " << size << '\n';
+    writer.stream() << "times " << size << " dd __float32__(0.0)" << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareStringArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dd " << size << std::endl;
-    writer.stream() << "%rep " << size << std::endl;
-    writer.stream() << "dd S3" << std::endl;
-    writer.stream() << "dd 0" << std::endl;
-    writer.stream() << "%endrep" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dd " << size << '\n';
+    writer.stream() << "%rep " << size << '\n';
+    writer.stream() << "dd S3" << '\n';
+    writer.stream() << "dd 0" << '\n';
+    writer.stream() << "%endrep" << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareIntVariable(const std::string& name, int value){
-    writer.stream() << "V" << name << " dd " << value << std::endl;
+    writer.stream() << "V" << name << " dd " << value << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareStringVariable(const std::string& name, const std::string& label, int size){
-    writer.stream() << "V" << name << " dd " << label << ", " << size << std::endl;
+    writer.stream() << "V" << name << " dd " << label << ", " << size << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareString(const std::string& label, const std::string& value){
-    writer.stream() << label << " dd " << value << std::endl;
+    writer.stream() << label << " dd " << value << '\n';
 }
 
 void as::IntelX86CodeGenerator::declareFloat(const std::string& label, double value){
-    writer.stream() << std::fixed << label << " dd __float32__(" << value << ")" << std::endl;
+    writer.stream() << std::fixed << label << " dd __float32__(" << value << ")" << '\n';
 }
 
 void as::IntelX86CodeGenerator::addStandardFunctions(){

--- a/src/asm/IntelX86_64CodeGenerator.cpp
+++ b/src/asm/IntelX86_64CodeGenerator.cpp
@@ -104,16 +104,16 @@ struct X86_64StatementCompiler : public boost::static_visitor<> {
                 if(instruction->size != ltac::Size::DEFAULT){
                     switch(instruction->size){
                         case ltac::Size::BYTE:
-                            writer.stream() << "movzx " << *instruction->arg1 << ", byte " << *instruction->arg2 << std::endl;
+                            writer.stream() << "movzx " << *instruction->arg1 << ", byte " << *instruction->arg2 << '\n';
                             break;
                         case ltac::Size::WORD:
-                            writer.stream() << "movzx " << *instruction->arg1 << ", word " << *instruction->arg2 << std::endl;
+                            writer.stream() << "movzx " << *instruction->arg1 << ", word " << *instruction->arg2 << '\n';
                             break;
                         case ltac::Size::DOUBLE_WORD:
-                            writer.stream() << "movzx " << *instruction->arg1 << ", dword " << *instruction->arg2 << std::endl;
+                            writer.stream() << "movzx " << *instruction->arg1 << ", dword " << *instruction->arg2 << '\n';
                             break;
                         default:
-                            writer.stream() << "mov " << *instruction->arg1 << ", qword " << *instruction->arg2 << std::endl;
+                            writer.stream() << "mov " << *instruction->arg1 << ", qword " << *instruction->arg2 << '\n';
                             break;
                     }
 
@@ -121,154 +121,154 @@ struct X86_64StatementCompiler : public boost::static_visitor<> {
                 }
 
                 if(boost::get<ltac::FloatRegister>(&*instruction->arg1) && boost::get<ltac::Register>(&*instruction->arg2)){
-                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else if(boost::get<ltac::Register>(&*instruction->arg1) && boost::get<ltac::FloatRegister>(&*instruction->arg2)){
-                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else if(boost::get<ltac::Address>(&*instruction->arg1)){
-                    writer.stream() << "mov qword " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "mov qword " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else {
-                    writer.stream() << "mov " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "mov " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::FMOV:
                 if(boost::get<ltac::FloatRegister>(&*instruction->arg1) && boost::get<ltac::Register>(&*instruction->arg2)){
-                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movq " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 } else {
-                    writer.stream() << "movsd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "movsd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::MEMSET:
-                writer.stream() << "mov rcx, " << *instruction->arg2 << std::endl;
-                writer.stream() << "xor rax, rax" << std::endl;
-                writer.stream() << "lea rdi, " << *instruction->arg1 << std::endl;
-                writer.stream() << "rep stosq" << std::endl;
+                writer.stream() << "mov rcx, " << *instruction->arg2 << '\n';
+                writer.stream() << "xor rax, rax" << '\n';
+                writer.stream() << "lea rdi, " << *instruction->arg1 << '\n';
+                writer.stream() << "rep stosq" << '\n';
 
                 break;
             case ltac::Operator::ENTER:
-                writer.stream() << "push rbp" << std::endl;
-                writer.stream() << "mov rbp, rsp" << std::endl;
+                writer.stream() << "push rbp" << '\n';
+                writer.stream() << "mov rbp, rsp" << '\n';
                 break;
             case ltac::Operator::LEAVE:
-                writer.stream() << "mov rsp, rbp" << std::endl;
-                writer.stream() << "pop rbp" << std::endl;
+                writer.stream() << "mov rsp, rbp" << '\n';
+                writer.stream() << "pop rbp" << '\n';
                 break;
             case ltac::Operator::RET:
-                writer.stream() << "ret" << std::endl;
+                writer.stream() << "ret" << '\n';
                 break;
             case ltac::Operator::CMP_INT:
-                writer.stream() << "cmp " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmp " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMP_FLOAT:
-                writer.stream() << "ucomisd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "ucomisd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::OR:
-                writer.stream() << "or " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "or " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::XOR:
-                writer.stream() << "xor " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "xor " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::PUSH:
                 if(boost::get<ltac::Address>(&*instruction->arg1)){
-                    writer.stream() << "push qword " << *instruction->arg1 << std::endl;
+                    writer.stream() << "push qword " << *instruction->arg1 << '\n';
                 } else {
-                    writer.stream() << "push " << *instruction->arg1 << std::endl;
+                    writer.stream() << "push " << *instruction->arg1 << '\n';
                 }
 
                 break;
             case ltac::Operator::POP:
-                writer.stream() << "pop " << *instruction->arg1 << std::endl;
+                writer.stream() << "pop " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::LEA:
-                writer.stream() << "lea " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "lea " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SHIFT_LEFT:
-                writer.stream() << "sal " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sal " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SHIFT_RIGHT:
-                writer.stream() << "sar " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sar " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::ADD:
-                writer.stream() << "add " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "add " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::SUB:
-                writer.stream() << "sub " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "sub " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::MUL2:
             case ltac::Operator::MUL3:
                 if(instruction->arg3){
-                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << ", " << *instruction->arg3 << std::endl;
+                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << ", " << *instruction->arg3 << '\n';
                 } else {
-                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                    writer.stream() << "imul " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 }
 
                 break;
             case ltac::Operator::DIV:
-                writer.stream() << "idiv " << *instruction->arg1 << std::endl;
+                writer.stream() << "idiv " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::FADD:
-                writer.stream() << "addsd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "addsd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FSUB:
-                writer.stream() << "subsd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "subsd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FMUL:
-                writer.stream() << "mulsd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "mulsd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::FDIV:
-                writer.stream() << "divsd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "divsd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::INC:
-                writer.stream() << "inc " << *instruction->arg1 << std::endl;
+                writer.stream() << "inc " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::DEC:
-                writer.stream() << "dec " << *instruction->arg1 << std::endl;
+                writer.stream() << "dec " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::NEG:
-                writer.stream() << "neg " << *instruction->arg1 << std::endl;
+                writer.stream() << "neg " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::NOT:
-                writer.stream() << "not " << *instruction->arg1 << std::endl;
+                writer.stream() << "not " << *instruction->arg1 << '\n';
                 break;
             case ltac::Operator::AND:
-                writer.stream() << "and " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "and " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::I2F:
-                writer.stream() << "cvtsi2sd " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cvtsi2sd " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::F2I:
-                writer.stream() << "cvttsd2si " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cvttsd2si " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVE:
-                writer.stream() << "cmove " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmove " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVNE:
-                writer.stream() << "cmovne " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovne " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVA:
-                writer.stream() << "cmova " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmova " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVAE:
-                writer.stream() << "cmovae " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovae " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVB:
-                writer.stream() << "cmovb " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovb " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVBE:
-                writer.stream() << "cmovbe " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovbe " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVG:
-                writer.stream() << "cmovg " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovg " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVGE:
-                writer.stream() << "cmovge " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovge " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVL:
-                writer.stream() << "cmovl " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovl " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::CMOVLE:
-                writer.stream() << "cmovle " << *instruction->arg1 << ", " << *instruction->arg2 << std::endl;
+                writer.stream() << "cmovle " << *instruction->arg1 << ", " << *instruction->arg2 << '\n';
                 break;
             case ltac::Operator::NOP:
                 //Nothing to output for a nop
@@ -281,49 +281,49 @@ struct X86_64StatementCompiler : public boost::static_visitor<> {
     void operator()(std::shared_ptr<ltac::Jump> jump){
         switch(jump->type){
             case ltac::JumpType::CALL:
-                writer.stream() << "call " << jump->label << std::endl;
+                writer.stream() << "call " << jump->label << '\n';
                 break;
             case ltac::JumpType::ALWAYS:
-                writer.stream() << "jmp " << "." << jump->label << std::endl;
+                writer.stream() << "jmp " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::NE:
-                writer.stream() << "jne " << "." << jump->label << std::endl;
+                writer.stream() << "jne " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::E:
-                writer.stream() << "je " << "." << jump->label << std::endl;
+                writer.stream() << "je " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::GE:
-                writer.stream() << "jge " << "." << jump->label << std::endl;
+                writer.stream() << "jge " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::G:
-                writer.stream() << "jg " << "." << jump->label << std::endl;
+                writer.stream() << "jg " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::LE:
-                writer.stream() << "jle " << "." << jump->label << std::endl;
+                writer.stream() << "jle " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::L:
-                writer.stream() << "jl " << "." << jump->label << std::endl;
+                writer.stream() << "jl " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::AE:
-                writer.stream() << "jae " << "." << jump->label << std::endl;
+                writer.stream() << "jae " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::A:
-                writer.stream() << "ja" << "." << jump->label << std::endl;
+                writer.stream() << "ja" << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::BE:
-                writer.stream() << "jbe " << "." << jump->label << std::endl;
+                writer.stream() << "jbe " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::B:
-                writer.stream() << "jb " << "." << jump->label << std::endl;
+                writer.stream() << "jb " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::P:
-                writer.stream() << "jp " << "." << jump->label << std::endl;
+                writer.stream() << "jp " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::Z:
-                writer.stream() << "jz " << "." << jump->label << std::endl;
+                writer.stream() << "jz " << "." << jump->label << '\n';
                 break;
             case ltac::JumpType::NZ:
-                writer.stream() << "jnz " << "." << jump->label << std::endl;
+                writer.stream() << "jnz " << "." << jump->label << '\n';
                 break;
             default:
                 eddic_unreachable("The jump type is not supported");
@@ -331,14 +331,14 @@ struct X86_64StatementCompiler : public boost::static_visitor<> {
     }
 
     void operator()(std::string& label){
-        writer.stream() << "." << label << ":" << std::endl;
+        writer.stream() << "." << label << ":" << '\n';
     }
 };
 
 } //end of anonymous namespace
 
 void as::IntelX86_64CodeGenerator::compile(mtac::function_p function){
-    writer.stream() << std::endl << function->getName() << ":" << std::endl;
+    writer.stream() << '\n' << function->getName() << ":" << '\n';
 
     X86_64StatementCompiler compiler(writer);
     
@@ -348,108 +348,108 @@ void as::IntelX86_64CodeGenerator::compile(mtac::function_p function){
 }
 
 void as::IntelX86_64CodeGenerator::writeRuntimeSupport(){
-    writer.stream() << "section .text" << std::endl << std::endl;
+    writer.stream() << "section .text" << '\n' << '\n';
 
-    writer.stream() << "global _start" << std::endl << std::endl;
+    writer.stream() << "global _start" << '\n' << '\n';
 
-    writer.stream() << "_start:" << std::endl;
+    writer.stream() << "_start:" << '\n';
     
     //If necessary init memory manager 
     if(context->exists("_F4mainAS") || context->referenceCount("_F4freePI") || context->referenceCount("_F5allocI") || context->referenceCount("_F6concatSS")){
-        writer.stream() << "call _F4init" << std::endl; 
+        writer.stream() << "call _F4init" << '\n'; 
     }
 
     //If the user wants the args, we add support for them
     if(context->exists("_F4mainAS")){
-        writer.stream() << "pop rbx" << std::endl;                          //rbx = number of args
+        writer.stream() << "pop rbx" << '\n';                          //rbx = number of args
         
         //Calculate the size of the array
-        writer.stream() << "mov rcx, rbx" << std::endl;
-        writer.stream() << "imul rcx, rcx, 16" << std::endl;
-        writer.stream() << "add rcx, 8" << std::endl;                       //rcx = size of the array
+        writer.stream() << "mov rcx, rbx" << '\n';
+        writer.stream() << "imul rcx, rcx, 16" << '\n';
+        writer.stream() << "add rcx, 8" << '\n';                       //rcx = size of the array
 
-        writer.stream() << "mov r14, rcx" << std::endl;
-        writer.stream() << "call _F5allocI" << std::endl;                   //rax = start address of the array
+        writer.stream() << "mov r14, rcx" << '\n';
+        writer.stream() << "call _F5allocI" << '\n';                   //rax = start address of the array
 
-        writer.stream() << "mov rsi, rax" << std::endl;         //rsi = last address of the array
-        writer.stream() << "mov rdx, rsi" << std::endl;                     //rdx = last address of the array
+        writer.stream() << "mov rsi, rax" << '\n';         //rsi = last address of the array
+        writer.stream() << "mov rdx, rsi" << '\n';                     //rdx = last address of the array
         
-        writer.stream() << "mov [rsi], rbx" << std::endl;                   //Set the length of the array
-        writer.stream() << "add rsi, 8" << std::endl;                       //Move to the destination address of the first arg
+        writer.stream() << "mov [rsi], rbx" << '\n';                   //Set the length of the array
+        writer.stream() << "add rsi, 8" << '\n';                       //Move to the destination address of the first arg
 
-        writer.stream() << ".copy_args:" << std::endl;
-        writer.stream() << "pop rdi" << std::endl;                          //rdi = address of current args
-        writer.stream() << "mov [rsi], rdi" << std::endl;                   //set the address of the string
+        writer.stream() << ".copy_args:" << '\n';
+        writer.stream() << "pop rdi" << '\n';                          //rdi = address of current args
+        writer.stream() << "mov [rsi], rdi" << '\n';                   //set the address of the string
 
         /* Calculate the length of the string  */
-        writer.stream() << "xor rax, rax" << std::endl;
-        writer.stream() << "xor rcx, rcx" << std::endl;
-        writer.stream() << "not rcx" << std::endl;
-        writer.stream() << "repne scasb" << std::endl;
-        writer.stream() << "not rcx" << std::endl;
-        writer.stream() << "dec rcx" << std::endl;
+        writer.stream() << "xor rax, rax" << '\n';
+        writer.stream() << "xor rcx, rcx" << '\n';
+        writer.stream() << "not rcx" << '\n';
+        writer.stream() << "repne scasb" << '\n';
+        writer.stream() << "not rcx" << '\n';
+        writer.stream() << "dec rcx" << '\n';
         /* End of the calculation */
 
-        writer.stream() << "mov [rsi+8], rcx" << std::endl;               //set the length of the string
-        writer.stream() << "add rsi, 16" << std::endl;
-        writer.stream() << "dec rbx" << std::endl;
-        writer.stream() << "jnz .copy_args" << std::endl;
+        writer.stream() << "mov [rsi+8], rcx" << '\n';               //set the length of the string
+        writer.stream() << "add rsi, 16" << '\n';
+        writer.stream() << "dec rbx" << '\n';
+        writer.stream() << "jnz .copy_args" << '\n';
 
-        writer.stream() << "push rdx" << std::endl;
+        writer.stream() << "push rdx" << '\n';
     }
 
     //Give control to the user function
     if(context->exists("_F4mainAS")){
-        writer.stream() << "call _F4mainAS" << std::endl;
+        writer.stream() << "call _F4mainAS" << '\n';
     } else {
-        writer.stream() << "call _F4main" << std::endl;
+        writer.stream() << "call _F4main" << '\n';
     }
 
     //Exit from the program
-    writer.stream() << "mov rax, 60" << std::endl;  //syscall 60 is exit
-    writer.stream() << "xor rdi, rdi" << std::endl; //exit code (0 = success)
-    writer.stream() << "syscall" << std::endl;
+    writer.stream() << "mov rax, 60" << '\n';  //syscall 60 is exit
+    writer.stream() << "xor rdi, rdi" << '\n'; //exit code (0 = success)
+    writer.stream() << "syscall" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::defineDataSection(){
-    writer.stream() << std::endl << "section .data" << std::endl;
+    writer.stream() << '\n' << "section .data" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareIntArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dq " << size << std::endl;
-    writer.stream() << "times " << size << " dq 0" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dq " << size << '\n';
+    writer.stream() << "times " << size << " dq 0" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareFloatArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dq " << size << std::endl;
-    writer.stream() << "times " << size << " dq __float64__(0.0)" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dq " << size << '\n';
+    writer.stream() << "times " << size << " dq __float64__(0.0)" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareStringArray(const std::string& name, unsigned int size){
-    writer.stream() << "V" << name << ":" <<std::endl;
-    writer.stream() << "dq " << size << std::endl;
-    writer.stream() << "%rep " << size << std::endl;
-    writer.stream() << "dq S3" << std::endl;
-    writer.stream() << "dq 0" << std::endl;
-    writer.stream() << "%endrep" << std::endl;
+    writer.stream() << "V" << name << ":" <<'\n';
+    writer.stream() << "dq " << size << '\n';
+    writer.stream() << "%rep " << size << '\n';
+    writer.stream() << "dq S3" << '\n';
+    writer.stream() << "dq 0" << '\n';
+    writer.stream() << "%endrep" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareIntVariable(const std::string& name, int value){
-    writer.stream() << "V" << name << " dq " << value << std::endl;
+    writer.stream() << "V" << name << " dq " << value << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareStringVariable(const std::string& name, const std::string& label, int size){
-    writer.stream() << "V" << name << " dq " << label << ", " << size << std::endl;
+    writer.stream() << "V" << name << " dq " << label << ", " << size << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareString(const std::string& label, const std::string& value){
-    writer.stream() << label << " dq " << value << std::endl;
+    writer.stream() << label << " dq " << value << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::declareFloat(const std::string& label, double value){
-    writer.stream() << label << std::fixed << " dq __float64__(" << value << ")" << std::endl;
+    writer.stream() << label << std::fixed << " dq __float64__(" << value << ")" << '\n';
 }
 
 void as::IntelX86_64CodeGenerator::addStandardFunctions(){


### PR DESCRIPTION
It is not necessary to use an std::stringstream as a memory buffer before
touching the file stream. std::ostream does already buffer the data
written to it in memory.
I removed the stringstream and made the assembly generator write
directly to the file stream.

The file stream is now explicitly flushed before assembling.

The hack for making small files work with nasm is no longer
necessary.
The real reason for the misbehaviour was that small
files fit into the file stream's memory buffer and were therefore
not written into the file until an explicit flush.
As the file stream's destruction caused a flush after assembling,
the problem was hardly observable.

I replaced many occurences of std::endl with '\n' because the former
would also flush the file stream. On a stringstream the behaviour is
equivalent.

The code is simpler now and preferring '\n' over endl is widely
considered good practice.
